### PR TITLE
chore(ci): replace scorecard.yml with reusable wrapper

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,39 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0-or-later
-name: OSSF Scorecard
-on:
-  push:
-    branches: [main, master]
-  schedule:
-    - cron: '0 4 * * 0'
+name: Scorecards supply-chain security
 
-# Estate guardrail: cancel superseded runs so re-pushes / rebased PR
-# updates do not pile up queued runs against the shared account-wide
-# Actions concurrency pool. Applied only to read-only check workflows
-# (no publish/mutation), so cancelling a superseded run is always safe.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '23 4 * * 1'
+  push:
+    branches: [main]
 
 permissions: read-all
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-        with:
-          persist-credentials: false
-
-      - name: Run Scorecard
-        uses: ossf/scorecard-action@05bb7c663f6ec9bd8484da0a5b5a77d423e3f88c # v2.3.1
-        with:
-          results_file: results.sarif
-          results_format: sarif
-
-      - name: Upload results
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
-        with:
-          sarif_file: results.sarif
+    uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@e0caf11508a3989574713c78f5f444f2ce5e33ef
+    secrets: inherit


### PR DESCRIPTION
Pins to hyperpolymath/standards#205 merge SHA `e0caf11508a3989574713c78f5f444f2ce5e33ef`. Replaces the canonical scorecard.yml with a thin wrapper. Closes the 5-candidate convergence set.

Estate audit: 258 deploys / 18% drift / 39% top-SHA share.

Part of estate-wide convergence campaign 2026-05-26 (standards#199 / #205).