### PR TITLE
ci(codeql): switch matrix javascript-typescript → actions (no JS source)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: javascript-typescript
+        - language: actions
           build-mode: none
         # Note: Rust is not yet supported by CodeQL
         # Python/Go are banned in this repo per RSR language policy


### PR DESCRIPTION
## Summary

`.github/workflows/codeql.yml` had `language: javascript-typescript` but this repo contains **zero JS/TS source files**. CodeQL's `analyze` job exited "configuration error: no source files" on every run.

## Fix

Switch the matrix to `language: actions` — CodeQL's workflow-scanning lane (inspects `.github/workflows/*.yml` for injection/leak patterns). Every repo has workflow files, so this lane always has signal.

## Estate-wide context

One of 4 zero-JS repos in the 2026-05-30 audit. Hypatia rule WF008 (`check_codeql_language_matrix_mismatch`) detects the pattern automatically going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)