### PR TITLE
chore(license): align Cargo.toml license to LICENSE (MPL-2.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Vext Contributors"]
-license = "MIT OR MPL-2.0"
+license = "MPL-2.0"
 repository = "https://github.com/Hyperpolymath/vext"
 
 [workspace.dependencies]


### PR DESCRIPTION
Closes #48.