### PR TITLE
ci: cut Actions burn — scope push triggers + concurrency-cancel

### DIFF
--- a/.github/workflows/language-policy.yml
+++ b/.github/workflows/language-policy.yml
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0-or-later
 name: Language Policy Enforcement
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
 # Estate guardrail: cancel superseded runs so re-pushes / rebased PR
 # updates do not pile up queued runs against the shared account-wide
 # Actions concurrency pool. Applied only to read-only check workflows


### PR DESCRIPTION
Automated by hypatia ci-health-sweep. Scopes `push` to the default branch (kills push+PR double-runs) and adds `concurrency: cancel-in-progress` to read-only PR checks. No SPDX/logic changes.